### PR TITLE
Feature/consonancelogtag and enable external logging settings file

### DIFF
--- a/action/action_compose.yml
+++ b/action/action_compose.yml
@@ -16,6 +16,7 @@ services:
       AWS_ACCESS_KEY_ID: "${aws_access_key_id}"
       AWS_REGION: "${aws_region}"
       DOCKSTORE_SERVER_URL: "${dockstore_server_url}"
+      EMAIL_FOR_VM_OWNER_TAG: "${email_address_for_owner_tag}"
       DOCKSTORE_TOKEN: "${dockstore_token}"
     volumes:
       - ~/dcc-action-service/logs:/home/ubuntu/logs

--- a/action/action_compose.yml
+++ b/action/action_compose.yml
@@ -16,7 +16,6 @@ services:
       AWS_ACCESS_KEY_ID: "${aws_access_key_id}"
       AWS_REGION: "${aws_region}"
       DOCKSTORE_SERVER_URL: "${dockstore_server_url}"
-      EMAIL_FOR_VM_OWNER_TAG: "${email_address_for_owner_tag}"
       DOCKSTORE_TOKEN: "${dockstore_token}"
     volumes:
       - ~/dcc-action-service/logs:/home/ubuntu/logs

--- a/action/conf/action.config.template
+++ b/action/conf/action.config.template
@@ -11,3 +11,4 @@ aws_secret_access_key={{ AWS_SECRET_ACCESS_KEY }}
 aws_access_key_id={{ AWS_ACCESS_KEY_ID }}
 aws_region={{ AWS_REGION }}
 aws_profile={{ AWS_PROFILE }}
+email_address_for_owner_tag={{ EMAIL_FOR_VM_OWNER_TAG }}

--- a/action/conf/action.config.template
+++ b/action/conf/action.config.template
@@ -11,4 +11,3 @@ aws_secret_access_key={{ AWS_SECRET_ACCESS_KEY }}
 aws_access_key_id={{ AWS_ACCESS_KEY_ID }}
 aws_region={{ AWS_REGION }}
 aws_profile={{ AWS_PROFILE }}
-email_address_for_owner_tag={{ EMAIL_FOR_VM_OWNER_TAG }}

--- a/consonance/example_tags.json
+++ b/consonance/example_tags.json
@@ -1,1 +1,1 @@
-{"Owner":"cgp@ucsc.edu"}
+{}

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -1026,6 +1026,11 @@ while [[ "${run_action^^}" != 'Y' &&  "${run_action^^}" != 'N' ]] ; do
       s3_touch_file_bucket='s3_touch_file_bucket'
       ask_question "What is your AWS S3 touch file bucket?" "$TOUCH_FILE_DIRECTORY" "S3 touch file bucket name" $s3_touch_file_bucket
 
+      email_address_for_owner_tag='cpg@ucsc.edu'
+      ask_question "What is the email address for the 'Owner' tag on the worker VM?" "$EMAIL_FOR_VM_OWNER_TAG" "Email for VM Owner tag" $email_address_for_owner_tag
+
+      sed -ie 's~{.*}~{"Owner","$email_address_for_owner_tag"}~' ./consonance/example_tags.json
+
       dockstore_token='0'
       dockstore_server_url='https://dockstore.org:8443'
 
@@ -1046,6 +1051,7 @@ while [[ "${run_action^^}" != 'Y' &&  "${run_action^^}" != 'N' ]] ; do
 "AWS_SECRET_ACCESS_KEY":"${aws_secret_access_key}",
 "TOUCH_FILE_DIRECTORY":"${s3_touch_file_bucket}",
 "DOCKSTORE_SERVER_URL":"${dockstore_server_url}",
+"EMAIL_FOR_VM_OWNER_TAG":"${email_address_for_owner_tag}",
 "DOCKSTORE_TOKEN":"${dockstore_token}"
 }
 CONFIG

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -1026,7 +1026,7 @@ while [[ "${run_action^^}" != 'Y' &&  "${run_action^^}" != 'N' ]] ; do
       s3_touch_file_bucket='s3_touch_file_bucket'
       ask_question "What is your AWS S3 touch file bucket?" "$TOUCH_FILE_DIRECTORY" "S3 touch file bucket name" $s3_touch_file_bucket
 
-      email_address_for_owner_tag='cpg@ucsc.edu'
+      email_address_for_owner_tag='email_address_for_owner_tag'
       ask_question "What is the email address for the 'Owner' tag on the worker VM?" "$EMAIL_FOR_VM_OWNER_TAG" "Email for VM Owner tag" $email_address_for_owner_tag
       sed -ie "s~{.*}~{\"Owner\":\"${email_address_for_owner_tag}\"}~" ./consonance/example_tags.json
 

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -370,6 +370,12 @@ while [[ "${run_consonance_launcher^^}" != 'Y' &&  "${run_consonance_launcher^^}
     fi
   done
 
+
+  email_address_for_owner_tag='email_address_for_owner_tag'
+  ask_question "What is the email address for the 'Owner' tag on the worker VM?" "$EMAIL_FOR_VM_OWNER_TAG" "Email for VM Owner tag" $email_address_for_owner_tag
+  sed -ie "s~{.*}~{\"Owner\":\"${email_address_for_owner_tag}\"}~" ./consonance/example_tags.json
+
+
   # Now write a config for this file.
   [[ -f commons_launcher_config/consonance.config ]] || mkdir -p commons_launcher_config
   # Note: You can't have ANY blank lines in .consonance/consonance.config because the python library that will eventually process it does not like blank lines and will fail.
@@ -410,7 +416,8 @@ while [[ "${run_consonance_launcher^^}" != 'Y' &&  "${run_consonance_launcher^^}
 "OS_ENDPOINT":"${user_os_endpoint}",
 "OS_NETWORK_ID":"${user_os_network_id}",
 "OS_REGION":"${user_os_region}",
-"OS_ZONE":"${user_os_zone}"
+"OS_ZONE":"${user_os_zone}",
+"EMAIL_FOR_VM_OWNER_TAG":"${email_address_for_owner_tag}"
 }
 CONFIG
   [[ -d "commons_launcher_config" ]] || mkdir "commons_launcher_config"
@@ -1026,10 +1033,6 @@ while [[ "${run_action^^}" != 'Y' &&  "${run_action^^}" != 'N' ]] ; do
       s3_touch_file_bucket='s3_touch_file_bucket'
       ask_question "What is your AWS S3 touch file bucket?" "$TOUCH_FILE_DIRECTORY" "S3 touch file bucket name" $s3_touch_file_bucket
 
-      email_address_for_owner_tag='email_address_for_owner_tag'
-      ask_question "What is the email address for the 'Owner' tag on the worker VM?" "$EMAIL_FOR_VM_OWNER_TAG" "Email for VM Owner tag" $email_address_for_owner_tag
-      sed -ie "s~{.*}~{\"Owner\":\"${email_address_for_owner_tag}\"}~" ./consonance/example_tags.json
-
       dockstore_token='0'
       dockstore_server_url='https://dockstore.org:8443'
 
@@ -1050,7 +1053,6 @@ while [[ "${run_action^^}" != 'Y' &&  "${run_action^^}" != 'N' ]] ; do
 "AWS_SECRET_ACCESS_KEY":"${aws_secret_access_key}",
 "TOUCH_FILE_DIRECTORY":"${s3_touch_file_bucket}",
 "DOCKSTORE_SERVER_URL":"${dockstore_server_url}",
-"EMAIL_FOR_VM_OWNER_TAG":"${email_address_for_owner_tag}",
 "DOCKSTORE_TOKEN":"${dockstore_token}"
 }
 CONFIG

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -1028,8 +1028,7 @@ while [[ "${run_action^^}" != 'Y' &&  "${run_action^^}" != 'N' ]] ; do
 
       email_address_for_owner_tag='cpg@ucsc.edu'
       ask_question "What is the email address for the 'Owner' tag on the worker VM?" "$EMAIL_FOR_VM_OWNER_TAG" "Email for VM Owner tag" $email_address_for_owner_tag
-
-      sed -ie 's~{.*}~{"Owner","$email_address_for_owner_tag"}~' ./consonance/example_tags.json
+      sed -ie "s~{.*}~{\"Owner\":\"${email_address_for_owner_tag}\"}~" ./consonance/example_tags.json
 
       dockstore_token='0'
       dockstore_server_url='https://dockstore.org:8443'


### PR DESCRIPTION
Add ability for user to set an 'Owner' tag for a VM which uses an email address (or any other string for that matter) which creates a tag for the VM

Also adds a logging settings file external to Consonance that allows a user to set the logging level so that the size of the log file does not grow so quickly