### PR TITLE
Add ansible config

### DIFF
--- a/consonance/Dockerfile_provisioner
+++ b/consonance/Dockerfile_provisioner
@@ -72,6 +72,9 @@ COPY ansible.config /root/.ansible.cfg
 COPY ssh.py /usr/lib/python2.7/dist-packages/ansible/plugins/connection/ssh.py
 RUN rm -f /usr/lib/python2.7/dist-packages/ansible/plugins/connection/ssh.pyc
 
+COPY ssh.py /usr/local/lib/python2.7/dist-packages/ansible/plugins/connection/ssh.py
+RUN rm -f /usr/local/lib/python2.7/dist-packages/ansible/plugins/connection/ssh.pyc
+
 # Setting up cronjob for refreshing worker's instance
 COPY boto.config /root/.boto
 RUN pip install paramiko==2.1.2

--- a/consonance/Dockerfile_provisioner
+++ b/consonance/Dockerfile_provisioner
@@ -65,6 +65,9 @@ RUN mkdir /consonance_logs && chmod a+rx /consonance_logs
 COPY bag_params.json /container-host-bag/example_params.json
 COPY example_tags.json /container-host-bag/example_tags.json
 
+# Remove ansible deprecation warnings
+COPY ansible.config /root/.ansible.cfg
+
 # patch for Ansible
 COPY ssh.py /usr/lib/python2.7/dist-packages/ansible/plugins/connection/ssh.py
 RUN rm -f /usr/lib/python2.7/dist-packages/ansible/plugins/connection/ssh.pyc

--- a/consonance/Dockerfile_provisioner
+++ b/consonance/Dockerfile_provisioner
@@ -72,6 +72,7 @@ COPY ansible.config /root/.ansible.cfg
 COPY ssh.py /usr/lib/python2.7/dist-packages/ansible/plugins/connection/ssh.py
 RUN rm -f /usr/lib/python2.7/dist-packages/ansible/plugins/connection/ssh.pyc
 
+# patch /usr/local/lib as well for Ansible
 COPY ssh.py /usr/local/lib/python2.7/dist-packages/ansible/plugins/connection/ssh.py
 RUN rm -f /usr/local/lib/python2.7/dist-packages/ansible/plugins/connection/ssh.pyc
 

--- a/consonance/ansible.config
+++ b/consonance/ansible.config
@@ -1,0 +1,3 @@
+[defaults]
+deprecation_warnings = False
+


### PR DESCRIPTION
Adds ansible config to the consonance provisioner to disable the deprecation warnings from the baked-in Ansible version in Consonance.