### PR TITLE
Updates metadata.jsons' ".meta" file

### DIFF
--- a/redwood/cli/admin/defaults.py
+++ b/redwood/cli/admin/defaults.py
@@ -30,4 +30,8 @@ DEFAULT_MONGODB_DB_NAME = 'dcc-metadata'
 MONGODB_URL = "{}/{}".format(DEFAULT_MONGODB_HOST,
                              DEFAULT_MONGODB_DB_NAME)
 
+INDEXER_CONTAINER = 'boardwalk_dcc-metadata-indexer_1'
+
 BUNDLE_METADATA_FILENAME = 'metadata.json'
+
+S3_BUCKET_EXPIRY_DAYS = 6


### PR DESCRIPTION
Adding the "is_deleted" flag to metadata.json changes its MD5 checksum and file size. The metadata.jsons' ".meta" file contains this info and needs to changed during the deletion process.